### PR TITLE
Rename the attendees list to other_attendees.

### DIFF
--- a/meetings/2025/2025-01-06-steering-council.md
+++ b/meetings/2025/2025-01-06-steering-council.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Jacob Kaplan-Moss
 ---
 

--- a/meetings/2025/2025-01-13-steering-council.md
+++ b/meetings/2025/2025-01-13-steering-council.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
 ---
 
 ## Agenda

--- a/meetings/2025/2025-01-20-steering-council.md
+++ b/meetings/2025/2025-01-20-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-01-27-steering-council.md
+++ b/meetings/2025/2025-01-27-steering-council.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-02-03-steering-council.md
+++ b/meetings/2025/2025-02-03-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Emmanuelle Delescolle
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
   - Natalia Bidart

--- a/meetings/2025/2025-02-10-steering-council.md
+++ b/meetings/2025/2025-02-10-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Natalia Bidart
 ---

--- a/meetings/2025/2025-02-17-steering-council.md
+++ b/meetings/2025/2025-02-17-steering-council.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
 ---
 

--- a/meetings/2025/2025-02-24-steering-council.md
+++ b/meetings/2025/2025-02-24-steering-council.md
@@ -4,7 +4,7 @@ members:
   - Emmanuelle Delescolle
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-03-03-steering-council.md
+++ b/meetings/2025/2025-03-03-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Emmanuelle Delescolle
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-03-10-steering-council.md
+++ b/meetings/2025/2025-03-10-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-03-17-steering-council.md
+++ b/meetings/2025/2025-03-17-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Emmanuelle Delescolle
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-03-24-steering-council.md
+++ b/meetings/2025/2025-03-24-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-03-31-steering-council-fellows.md
+++ b/meetings/2025/2025-03-31-steering-council-fellows.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
   - Natalia Bidart

--- a/meetings/2025/2025-04-14-steering-council.md
+++ b/meetings/2025/2025-04-14-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Carlton 
   - Lily
   - Frank
-attendees:
+other_attendees:
   - Catherine 
 ---
 

--- a/meetings/2025/2025-04-28-steering-council-fellows.md
+++ b/meetings/2025/2025-04-28-steering-council-fellows.md
@@ -4,7 +4,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
   - Natalia Bidart

--- a/meetings/2025/2025-05-12-steering-council.md
+++ b/meetings/2025/2025-05-12-steering-council.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
   - Natalia Bidart

--- a/meetings/2025/2025-05-26-steering-council-fellows.md
+++ b/meetings/2025/2025-05-26-steering-council-fellows.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Natalia Bidart
 ---

--- a/meetings/2025/2025-06-23-steering-council-fellows.md
+++ b/meetings/2025/2025-06-23-steering-council-fellows.md
@@ -4,7 +4,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Natalia Bidart
   - Sarah Boyce

--- a/meetings/2025/2025-07-07-steering-council.md
+++ b/meetings/2025/2025-07-07-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Emma Delescolle
   - Frank Wiles
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
 ---
 

--- a/meetings/2025/2025-07-21-steering-council.md
+++ b/meetings/2025/2025-07-21-steering-council.md
@@ -4,7 +4,7 @@ members:
   - Emma Delescolle
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-09-01-steering-council-with-fellows.md
+++ b/meetings/2025/2025-09-01-steering-council-with-fellows.md
@@ -5,7 +5,7 @@ members:
   - Emma Delescolle
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Walls
   - Natalia Bidart

--- a/meetings/2025/2025-09-15-steering-council.md
+++ b/meetings/2025/2025-09-15-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Kaplan-Moss
 ---

--- a/meetings/2025/2025-10-06-steering-council-with-fellows.md
+++ b/meetings/2025/2025-10-06-steering-council-with-fellows.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Natalia Bidart
 ---

--- a/meetings/2025/2025-10-13-steering-council.md
+++ b/meetings/2025/2025-10-13-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Foote
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Natalia Bidart
 ---

--- a/meetings/2025/2025-11-03-steering-council-with-fellows.md
+++ b/meetings/2025/2025-11-03-steering-council-with-fellows.md
@@ -5,7 +5,7 @@ members:
   - Emma Delescolle
   - Frank Wiles
   - Lily Acorn
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Walls
   - Natalia Bidart

--- a/meetings/2025/2025-11-17-steering-council.md
+++ b/meetings/2025/2025-11-17-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Acorn
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
 ---
 

--- a/meetings/2025/2025-12-01-steering-council-with-fellows.md
+++ b/meetings/2025/2025-12-01-steering-council-with-fellows.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Acorn
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Walls
   - Natalia Bidart

--- a/meetings/2025/2025-12-15-steering-council.md
+++ b/meetings/2025/2025-12-15-steering-council.md
@@ -5,7 +5,7 @@ members:
   - Frank Wiles
   - Lily Acorn
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
 ---
 

--- a/meetings/2026/2026-01-05-steering-council-with-fellows.md
+++ b/meetings/2026/2026-01-05-steering-council-with-fellows.md
@@ -6,7 +6,7 @@ members:
   - Frank Wiles
   - Lily Acorn
   - Tim Schilling
-attendees:
+other_attendees:
   - Catherine Holmes
   - Jacob Walls
   - Natalia Bidart

--- a/meetings/template.md
+++ b/meetings/template.md
@@ -2,7 +2,7 @@
 date: YYYY-MM-DD
 members:
   - [Steering council members]
-attendees:
+other_attendees:
   - [Other attendees]
 ---
 


### PR DESCRIPTION
This is more accurate as attendees may have suggested they were the only attendees rather than non-steering council members.